### PR TITLE
Improve button focus outline

### DIFF
--- a/bannerRole.js
+++ b/bannerRole.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var bannerRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      constraints: ['direct descendant of document'],
+      name: 'header'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = bannerRole;
+exports.default = _default;


### PR DESCRIPTION
Increase visibility for keyboard users by enhancing the button focus outline contrast and thickness. Add :focus-visible rules, remove outline:none overrides on primary/secondary buttons, and include a subtle box-shadow to meet accessibility contrast requirements.