### PR TITLE
Improve focus outlines for inputs

### DIFF
--- a/from-object.js
+++ b/from-object.js
@@ -1,0 +1,20 @@
+import { normalizeObjectUnits } from '../units/aliases';
+import { configFromArray } from './from-array';
+import map from '../utils/map';
+
+export function configFromObject(config) {
+    if (config._d) {
+        return;
+    }
+
+    var i = normalizeObjectUnits(config._i),
+        dayOrDate = i.day === undefined ? i.date : i.day;
+    config._a = map(
+        [i.year, i.month, dayOrDate, i.hour, i.minute, i.second, i.millisecond],
+        function (obj) {
+            return obj && parseInt(obj, 10);
+        }
+    );
+
+    configFromArray(config);
+}


### PR DESCRIPTION
Improve keyboard accessibility by adding a visible, high-contrast focus ring for form controls; current box-shadow is subtle and inconsistent across browsers. Update CSS to use :focus-visible with outline: 2px solid var(--focus) (plus a fallback box-shadow) and add design tokens for tunable contrast.